### PR TITLE
[#211] Fix SSP uploading cache step failing with 413

### DIFF
--- a/al-nginx/nginx.conf
+++ b/al-nginx/nginx.conf
@@ -6,8 +6,6 @@ events {
 
 http {
 
-    client_max_body_size 100M;
-
     include mime.types;
     default_type application/octet-stream;
 
@@ -52,6 +50,8 @@ http {
 
         location /modelujeme/sluzby/db-server/ {
             proxy_pass http://al-db-server:7200/; # keep the trailing slash to cut off matched prefix
+
+            client_max_body_size 512M; # required by SSP deploy to update big RDF graphs
 
             proxy_connect_timeout 500;
             proxy_send_timeout 500;


### PR DESCRIPTION
Resolves #211.


By fixing SSP deploy script related to step "(DEV) AL - Uploading cache" and error "curl: (22) The requested URL returned error: 413"